### PR TITLE
Add chatgpt-mac menubar app

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@
 - [Twitter Bot](https://github.com/transitive-bullshit/chatgpt-twitter-bot) powered by ChatGPT
 - [Chrome extension](https://github.com/kazuki-sf/ChatGPT_Extension)
 - [Google docs](https://github.com/cesarhuret/docGPT)
+- [Mac menubar app](https://github.com/vincelwt/chatgpt-mac)
 
 
 ### CLI tools


### PR DESCRIPTION
Propose adding the ChatGPT menubar app (mainly for Mac at the moment).