### PR TITLE
docs: fix npm package description

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 ### API tools
 - [Unoffical API in Python](https://github.com/acheong08/ChatGPT)
 - [TLS-based API (Python)](https://github.com/rawandahmad698/PyChatGPT)
-- [Unofficial API using a headless browser](https://github.com/transitive-bullshit/chatgpt-api)
+- [Unofficial API in JS/TS](https://github.com/transitive-bullshit/chatgpt-api)
 - [Unofficial API in Dart](https://github.com/MisterJimson/chatgpt_api_dart)
 
 


### PR DESCRIPTION
The `chatgpt` NPM package hasn't used a headless browser since v1.0.0 about a week ago, so just updated it to reflect that it supports JS / TS.

It's already being used to power 20+ live project / products 🔥 https://github.com/transitive-bullshit/chatgpt-api#projects

Cheers 😄 