### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@
 ### CLI tools
 - [Voice-based chatGPT](https://github.com/platelminto/chatgpt-conversation)
 - [Explain your runtime errors with ChatGPT](https://github.com/shobrook/stackexplain)
-- [GPT3 WordPress post generator](https://github.com/nicolaballotta/gtp3-wordpress-post-generator)
+- [GPT3 WordPress post generator](https://github.com/nicolaballotta/gpt3-wordpress-post-generator)
 - [Assistant CLI](https://github.com/diciaup/assistant-cli)
 
 ### Github Actions


### PR DESCRIPTION
Changed GPT3 WordPress post generator url, to fix a typo in the initial repository.