### PR TITLE
Add ChatGPT Starter Kit for Laravel

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@
 - [Jetbrains IDEs plugin](https://github.com/LiLittleCat/intellij-chatgpt)
 - [ChatGPT for Slack Bot](https://github.com/pedrorito/ChatGPTSlackBot)
 - [ChatGPT for Discord Bot](https://github.com/m1guelpf/chatgpt-discord)
+- [ChatGPT Starter Kit for Laravel](https://dev.to/bhaidar/chatgpt-starter-template-in-laravel-1klk)
 
 
 ### Social Tools


### PR DESCRIPTION
Adding ChatGPT Starter Kit for Laravel under the section `Access ChatGPT from other platforms`