### PR TITLE
Add chatgpt-prompts npm library to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Awesome ChatGPT 
-[![Twitter](https://img.shields.io/twitter/url.svg?label=Follow%20%40humanloop&style=social&url=https%3A%2F%2Ftwitter.com-humanloop)](https://twitter.com/humanloop) 
+# Awesome ChatGPT
 
+[![Twitter](https://img.shields.io/twitter/url.svg?label=Follow%20%40humanloop&style=social&url=https%3A%2F%2Ftwitter.com-humanloop)](https://twitter.com/humanloop)
 
 ![ChatGPT](/chatgpt-header.png)
 
@@ -13,17 +13,19 @@
 - [chatGPT launch blog](https://openai.com/blog/chatgpt/)
 
 #### ChatGPT Community / Discussion
+
 - [OpenAI Discord Channel](https://discord.com/invite/openai)
 
-
 ### API tools
+
 - [Unoffical API in Python](https://github.com/acheong08/ChatGPT)
 - [TLS-based API (Python)](https://github.com/rawandahmad698/PyChatGPT)
 - [Unofficial API in JS/TS](https://github.com/transitive-bullshit/chatgpt-api)
+- [ChatGPT Prompts library in JS/TS](https://github.com/pacholoamit/chatgpt-prompts)
 - [Unofficial API in Dart](https://github.com/MisterJimson/chatgpt_api_dart)
 
-
 ### Chrome Extensions
+
 - [Chrome extension to access ChatGPT as a popup on any page](https://github.com/kazuki-sf/ChatGPT_Extension)
 - [Extension to display ChatGPT response alongside Google Search results](https://github.com/wong2/chat-gpt-google-extension)
 - [Extension to add share abilities to ChatGPT (PDF, PNG or a sharable link](https://github.com/liady/ChatGPT-pdf)
@@ -31,8 +33,8 @@
 - [ChassistantGPT - embeds ChatGPT as a hands-free voice assistant in the background](https://github.com/idosal/assistant-chat-gpt)
 - [WebChatGPT - augment your prompts to ChatGPT with web search results](https://github.com/qunash/chatgpt-advanced/)
 
-
 ### Access ChatGPT from other platforms
+
 - [Serverless Telegram bot](https://github.com/franalgaba/chatgpt-telegram-bot-serverless)
 - [WhatsApp bot](https://github.com/danielgross/whatsapp-gpt)
 - [RayCast Extension (unofficial)](https://github.com/abielzulio/chatgpt-raycast)
@@ -48,38 +50,39 @@
 - [ChatGPT for Slack Bot](https://github.com/pedrorito/ChatGPTSlackBot)
 - [ChatGPT for Discord Bot](https://github.com/m1guelpf/chatgpt-discord)
 
-
 ### Social Tools
+
 - [shareGPT - permenent links to your conversations](https://github.com/domeccleston/sharegpt)
 
 ### Applications
+
 - [ChatARKit: Using ChatGPT to Create AR Experiences with Natural Language](https://github.com/trzy/ChatARKit)
 - [GPT3 Blog Post Generator](https://github.com/simplysabir/AI-Writing-Assistant)
 - [Debugger that fixes errors and explains them with GPT-3](https://github.com/shobrook/adrenaline/)
 
 ### CLI tools
+
 - [Voice-based chatGPT](https://github.com/platelminto/chatgpt-conversation)
 - [Explain your runtime errors with ChatGPT](https://github.com/shobrook/stackexplain)
 - [GPT3 WordPress post generator](https://github.com/nicolaballotta/gtp3-wordpress-post-generator)
 - [Assistant CLI](https://github.com/diciaup/assistant-cli)
 
 ### Github Actions
+
 - [ChatGPT Code Review](https://github.com/kxxt/chatgpt-action)
 
 ### Cybersecurity
+
 - [Beelzebub ChatGPT Honeypot](https://github.com/mariocandela/beelzebub)
 - [Penetration Testing Findings Generator](https://github.com/Stratus-Security/FinGen)
 
 ### Example prompts
-- [Awesome ChatGPT prompts](https://github.com/f/awesome-chatgpt-prompts) 
-... just follow [@goodside](https://twitter.com/goodside)
 
-
-
+- [Awesome ChatGPT prompts](https://github.com/f/awesome-chatgpt-prompts)
+  ... just follow [@goodside](https://twitter.com/goodside)
 
 ---
 
 ### Contribution
 
 This list started as personal collection of interesting things about chatGPT from OpenAI. Your contributions and suggestions are warmly welcomed.
-

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Awesome ChatGPT
+# Awesome ChatGPT 
+[![Twitter](https://img.shields.io/twitter/url.svg?label=Follow%20%40humanloop&style=social&url=https%3A%2F%2Ftwitter.com-humanloop)](https://twitter.com/humanloop) 
 
-[![Twitter](https://img.shields.io/twitter/url.svg?label=Follow%20%40humanloop&style=social&url=https%3A%2F%2Ftwitter.com-humanloop)](https://twitter.com/humanloop)
 
 ![ChatGPT](/chatgpt-header.png)
 
@@ -13,19 +13,18 @@
 - [chatGPT launch blog](https://openai.com/blog/chatgpt/)
 
 #### ChatGPT Community / Discussion
-
 - [OpenAI Discord Channel](https://discord.com/invite/openai)
 
-### API tools
 
+### API tools
 - [Unoffical API in Python](https://github.com/acheong08/ChatGPT)
 - [TLS-based API (Python)](https://github.com/rawandahmad698/PyChatGPT)
 - [Unofficial API in JS/TS](https://github.com/transitive-bullshit/chatgpt-api)
 - [ChatGPT Prompts library in JS/TS](https://github.com/pacholoamit/chatgpt-prompts)
 - [Unofficial API in Dart](https://github.com/MisterJimson/chatgpt_api_dart)
 
-### Chrome Extensions
 
+### Chrome Extensions
 - [Chrome extension to access ChatGPT as a popup on any page](https://github.com/kazuki-sf/ChatGPT_Extension)
 - [Extension to display ChatGPT response alongside Google Search results](https://github.com/wong2/chat-gpt-google-extension)
 - [Extension to add share abilities to ChatGPT (PDF, PNG or a sharable link](https://github.com/liady/ChatGPT-pdf)
@@ -33,8 +32,8 @@
 - [ChassistantGPT - embeds ChatGPT as a hands-free voice assistant in the background](https://github.com/idosal/assistant-chat-gpt)
 - [WebChatGPT - augment your prompts to ChatGPT with web search results](https://github.com/qunash/chatgpt-advanced/)
 
-### Access ChatGPT from other platforms
 
+### Access ChatGPT from other platforms
 - [Serverless Telegram bot](https://github.com/franalgaba/chatgpt-telegram-bot-serverless)
 - [WhatsApp bot](https://github.com/danielgross/whatsapp-gpt)
 - [RayCast Extension (unofficial)](https://github.com/abielzulio/chatgpt-raycast)
@@ -50,39 +49,38 @@
 - [ChatGPT for Slack Bot](https://github.com/pedrorito/ChatGPTSlackBot)
 - [ChatGPT for Discord Bot](https://github.com/m1guelpf/chatgpt-discord)
 
-### Social Tools
 
+### Social Tools
 - [shareGPT - permenent links to your conversations](https://github.com/domeccleston/sharegpt)
 
 ### Applications
-
 - [ChatARKit: Using ChatGPT to Create AR Experiences with Natural Language](https://github.com/trzy/ChatARKit)
 - [GPT3 Blog Post Generator](https://github.com/simplysabir/AI-Writing-Assistant)
 - [Debugger that fixes errors and explains them with GPT-3](https://github.com/shobrook/adrenaline/)
 
 ### CLI tools
-
 - [Voice-based chatGPT](https://github.com/platelminto/chatgpt-conversation)
 - [Explain your runtime errors with ChatGPT](https://github.com/shobrook/stackexplain)
 - [GPT3 WordPress post generator](https://github.com/nicolaballotta/gtp3-wordpress-post-generator)
 - [Assistant CLI](https://github.com/diciaup/assistant-cli)
 
 ### Github Actions
-
 - [ChatGPT Code Review](https://github.com/kxxt/chatgpt-action)
 
 ### Cybersecurity
-
 - [Beelzebub ChatGPT Honeypot](https://github.com/mariocandela/beelzebub)
 - [Penetration Testing Findings Generator](https://github.com/Stratus-Security/FinGen)
 
 ### Example prompts
+- [Awesome ChatGPT prompts](https://github.com/f/awesome-chatgpt-prompts) 
+... just follow [@goodside](https://twitter.com/goodside)
 
-- [Awesome ChatGPT prompts](https://github.com/f/awesome-chatgpt-prompts)
-  ... just follow [@goodside](https://twitter.com/goodside)
+
+
 
 ---
 
 ### Contribution
 
 This list started as personal collection of interesting things about chatGPT from OpenAI. Your contributions and suggestions are warmly welcomed.
+


### PR DESCRIPTION
Hello!

I've created a library that extends the usage of the [Unofficial NodeJS client for ChatGPT](https://github.com/transitive-bullshit/chatgpt-api). In a nutshell the [chatgpt-prompts](https://github.com/pacholoamit/chatgpt-prompts) package contains all of the 149 Prompts listed in [awesome-chatgpt-prompts](https://github.com/f/awesome-chatgpt-prompts) so that users can re-use the amazing community made prompts instantly.