### PR TITLE
feat: add ChatGPT for Feishu Bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@
 - [Jetbrains IDEs plugin](https://github.com/LiLittleCat/intellij-chatgpt)
 - [ChatGPT for Slack Bot](https://github.com/pedrorito/ChatGPTSlackBot)
 - [ChatGPT for Discord Bot](https://github.com/m1guelpf/chatgpt-discord)
+- [ChatGPT for Feishu Bot](https://github.com/go-zoox/chatgpt-for-chatbot-feishu)
 
 
 ### Social Tools


### PR DESCRIPTION
###
* zh_cn: ChatGPT for ChatBot Feishu 是一个快速将 ChatGPT 接入飞书的应用，基于 OpenAI 官方接口 GPT3 模型，支持私有部署，作为私人工作助理或者企业员工助理。
* en_us: ChatGPT for ChatBot Feishu is an app for quickly integrating ChatGPT with Feishu, based on the official OpenAI interface GPT-3 model and supporting private deployment, which can be used as a personal assistant for work or an enterprise employee assistant. (Translated by it)

### Git Repo
* https://github.com/go-zoox/chatgpt-for-chatbot-feishu

### License
* MIT