### PR TITLE
Added a link to GoLang client for a new ChatGPT API

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 - [TLS-based API (Python)](https://github.com/rawandahmad698/PyChatGPT)
 - [Unofficial API in JS/TS](https://github.com/transitive-bullshit/chatgpt-api)
 - [Unofficial API in Dart](https://github.com/MisterJimson/chatgpt_api_dart)
-
+- [ChatGPT (GPT-3.5-turbo) API Client in Golang](https://github.com/AlmazDelDiablo/gpt3-5-turbo-go)
 
 ### Chrome Extensions
 - [Chrome extension to access ChatGPT as a popup on any page](https://github.com/kazuki-sf/ChatGPT_Extension)


### PR DESCRIPTION
OpenAI just released an official API for ChatGPT. So, I created a client for GoLang. 
Official guide: https://platform.openai.com/docs/guides/chat