### PR TITLE
Add open source ChatGPT web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@
 ### Applications
 - [Adrenaline: Debugger that fixes errors and explains them with GPT-3](https://github.com/shobrook/adrenaline/)
 - [ChatARKit: Using ChatGPT to Create AR Experiences with Natural Language](https://github.com/trzy/ChatARKit)
+- [Chat with GPT: Open source ChatGPT web UI](https://github.com/cogentapps/chat-with-gpt)
 - [GPT3 Blog Post Generator](https://github.com/simplysabir/AI-Writing-Assistant)
 
 ### CLI tools


### PR DESCRIPTION
I’ve been working on this open source ChatGPT web UI for fun. It has some features the official UI doesn’t like search, sharing and realistic text to speech (via elevenlabs). The code might be interesting to other developers who are interested in integrating with the ChatGPT API.