### PR TITLE
Add GPT-Voice-Conversation-Chatbot to CLI Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@
 - [GPT3 Blog Post Generator](https://github.com/simplysabir/AI-Writing-Assistant)
 
 ### CLI tools
+- [Conversational and personalizable ChatGPT chatbot with memory and a supportive personality](https://github.com/Adri6336/gpt-voice-conversation-chatbot)
 - [Voice-based chatGPT](https://github.com/platelminto/chatgpt-conversation)
 - [Explain your runtime errors with ChatGPT](https://github.com/shobrook/stackexplain)
 - [GPT3 WordPress post generator](https://github.com/nicolaballotta/gtp3-wordpress-post-generator)


### PR DESCRIPTION
This is a project I've been working on where I aimed to make ChatGPT more personable while not impairing its ability to be used for general questions. What sets it apart from the other ChatGPT tools is that it is fundamentally designed to be conversational in nature. To that end, I have made it so that you can communicate with it via the command line or through your microphone, gave users the ability to have the bot remember topics and information mentioned in their conversation (e.g. my instance knows my name and refers to me by it every now and then), made a system for token recycling so that users can speak with the bot for as long as they want without being limited by the 4096 token maximum, hear its responses with ElevenLabs TTS, personalize its name and conversational preset (a line of text appended to the start of every conversation to alter how ChatGPT responds), and have the bot engage with them in a positive and supportive way.