### PR TITLE
Add README-AI to 'CLI tools' section of awesome-chatgpt

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@
 - [GPT3 Blog Post Generator](https://github.com/simplysabir/AI-Writing-Assistant)
 
 ### CLI tools
+- [README-AI: Generate aesthetic, structured, and informative README.md files](https://github.com/eli64s/README-AI) 
 - [Voice-based chatGPT](https://github.com/platelminto/chatgpt-conversation)
 - [Explain your runtime errors with ChatGPT](https://github.com/shobrook/stackexplain)
 - [GPT3 WordPress post generator](https://github.com/nicolaballotta/gtp3-wordpress-post-generator)


### PR DESCRIPTION
Hello,

I would like to submit a pull request to add a new project, [README-AI](https://github.com/eli64s/README-AI), to the [CLI tools](https://github.com/humanloop/awesome-chatgpt#cli-tools) list of the awesome-chatgpt repository.

README-AI is a command-line tool that uses OpenAI's language model API to help users create visually appealing, structured, and informative README.md files for their projects. This tool can benefit developers and teams of all levels by providing a straightforward method for producing baseline documentation for their codebases.

Thank you for taking the time to review this pull request!