### PR TITLE
Added aider CLI tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@
 - [AI Commit - Automagically generate conventional commit messages with AI](https://github.com/guanguans/ai-commit)
 - [Use ChatGPT to generate PPT automatically, all in one single file](https://github.com/williamfzc/chat-gpt-ppt)
 - [SearchGPT: Connecting ChatGPT with the Internet](https://github.com/tobiasbueschel/search-gpt)
+- [aider - GPT-4 powered coding in the terminal](https://github.com/paul-gauthier/aider)
 
 ### DevOps
 - [ChatGPT Code Review](https://github.com/kxxt/chatgpt-action)


### PR DESCRIPTION
I would like to propose adding `aider` to the Awesome ChatGPT list.

`aider` is a command-line chat tool that allows developers to code with GPT-4 in the terminal. Users can ask GPT for features, improvements, or bug fixes, and `aider` will apply the suggested changes to their source files. Each change is automatically committed to git with a descriptive commit message.

You can find more information about `aider` in its GitHub repository: https://github.com/paul-gauthier/aider

I believe that `aider` would be a valuable addition to the list, as it showcases a practical application of GPT-4 in a developer's workflow.

Please let me know if you need any additional information or if there are any changes required for the inclusion of `aider` in the list.

Thank you for considering this request.

Best,
Paul
