### PR TITLE
Add OpenAgents from XLang NLP Lab.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@
 - [ChatGPT for Slack Bot](https://github.com/pedrorito/ChatGPTSlackBot)
 - [ChatGPT for Discord Bot](https://github.com/m1guelpf/chatgpt-discord)
 - [MindMac](https://mindmac.app) - An intuitive macOS app, powered by ChatGPT API and designed for maximum productivity. Built-in prompt templates, support GPT-3.5 and GPT-4. Currently available in 15 languages.
+- [OpenAgents](https://github.com/xlang-ai/OpenAgents) - A replicate version of ChatGPT Plus products including Code Interpreter, Plugins and Web Browse with Bing.
 
 ### Tutorials
 - [Create your first app using ChatGPT](https://genez.io/blog/create-your-first-app-using-chatgpt/)


### PR DESCRIPTION
Hi, this is XLang Lab from the University of Hong Kong, we made an application-ready open-source version of ChatGPT Plus Products (including Code Interpreter, Plugins and Web Browsing with Bing), and we would like to contribute to this repo as an open-source demo as well as framework, hope you enjoy it! 

abs: https://arxiv.org/abs/2310.10634
pdf: https://arxiv.org/pdf/2310.10634.pdf
Code: https://github.com/xlang-ai/OpenAgents 
Demos: https://chat.xlang.ai 
Docs: https://docs.xlang.ai

Thanks!