### PR TITLE
Add Arch Tools — 61-tool API platform for ChatGPT and AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@
 - [Unofficial API in Dart](https://github.com/MisterJimson/chatgpt_api_dart)
 - [ChatGPT (GPT-3.5-turbo) API Client in Golang](https://github.com/AlmazDelDiablo/gpt3-5-turbo-go)
 
+- [Arch Tools](https://archtools.dev) - 58 API tools behind one key. MCP native + x402 USDC payments on 15 chains. Web scraping, AI generation, crypto, voice, email, and more.
+
 ### Chrome Extensions
 - [Chrome extension to access ChatGPT as a popup on any page](https://github.com/kazuki-sf/ChatGPT_Extension)
 - [Extension to display ChatGPT response alongside Google Search results](https://github.com/wong2/chat-gpt-google-extension)


### PR DESCRIPTION
## Add Arch Tools

[Arch Tools](https://archtools.dev) is a unified API platform offering 58 production-ready tools behind a single API key.

### Key Features:
- **MCP Native** - Works as a Model Context Protocol server for AI agents
- **x402 Payments** - USDC payments on 15 blockchain networks via Coinbase x402 protocol
- **58 Tools** - Web scraping, AI generation, crypto, voice, email, and more
- **Single API Key** - One key for all tools

### Links:
- Website: https://archtools.dev
- GitHub: https://github.com/Deesmo/Arch-AI-Tools
